### PR TITLE
changing the data table with w-full remove space

### DIFF
--- a/components/dataTable/DataTable.tsx
+++ b/components/dataTable/DataTable.tsx
@@ -45,7 +45,7 @@ export const DataTable = ({
   });
 
   return (
-    <table className={`border-collapse rounded-md bg-tableHD ${className}`}>
+    <table className={`border-collapse w-full rounded-md bg-tableHD ${className}`}>
       <thead>
         <tr className="sticky top-0">{headerElements}</tr>
       </thead>


### PR DESCRIPTION
**What type of PR is this? (check applicable) 🚧**

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

**Describe your PR request 🔥**
fixed the extra space on the data table
by adding w-full to the datatable.tsx 
**Mobile & Desktop Screenshots/Recordings 📷**
![image](https://user-images.githubusercontent.com/78330666/233740358-4948beab-d4a4-4b2f-8a22-1c6bf8ec4fe5.png)

<!-- 
UI changes should be accompanied by screenshots or recordings. Please upload/link them here. 
Guide to linking images here:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#uploading-assets
-->

**Related Issues 🩹**
Closes #54 
<!-- 
Example: 
Resolves #123
Closes #456

Guide to linking issues here:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->